### PR TITLE
Do not open JsonRPC port if only running in console mode.

### DIFF
--- a/src/eth/main.cpp
+++ b/src/eth/main.cpp
@@ -1058,9 +1058,6 @@ int main(int argc, char** argv)
 	else
 		cout << "Networking disabled. To start, use netstart or pass --bootstrap or a remote host." << endl;
 
-	if (useConsole && jsonRPCURL == -1)
-		jsonRPCURL = SensibleHttpPort;
-
 #if ETH_JSONRPC || !ETH_TRUE
 	shared_ptr<dev::WebThreeStubServer> jsonrpcServer;
 	unique_ptr<jsonrpc::AbstractServerConnector> jsonrpcConnector;


### PR DESCRIPTION
JSONRPC is not needed for the JSConsole, but it is activated nevertheless.
This poses a critical security risk as the json rpc interface is not protected at all (anyone can create transactions by connecting to the json rpc server which do not need to be confirmed).
