### PR TITLE
Add link to ethash-cl where required for windows

### DIFF
--- a/eth/CMakeLists.txt
+++ b/eth/CMakeLists.txt
@@ -6,7 +6,8 @@ file(GLOB HEADERS "*.h")
 
 add_executable(${EXECUTABLE} ${SRC_LIST} ${HEADERS})
 
-eth_use(${EXECUTABLE} REQUIRED Web3::web3jsonrpc JsonRpc::Client Web3::jsconsole)
+set(ETHASHCL 1)
+eth_use(${EXECUTABLE} REQUIRED Web3::web3jsonrpc JsonRpc::Client Web3::jsconsole Eth::ethash-cl)
 eth_use(${EXECUTABLE} OPTIONAL Readline)
 
 if (APPLE)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,7 @@ aux_source_directory(./libwhisper SRCS)
 file(GLOB HEADERS "*.h")
 add_executable(testweb3 ${SRCS} ${HEADERS})
 
-eth_use(testweb3 REQUIRED Web3::web3jsonrpc JsonRpc::Client)
+set(ETHASHCL 1)
+eth_use(testweb3 REQUIRED Web3::web3jsonrpc JsonRpc::Client Eth::ethash-cl)
 
 target_link_libraries(testweb3 ${Boost_UNIT_TEST_FRAMEWORK_LIBRARIES})

--- a/test/ethrpctest/CMakeLists.txt
+++ b/test/ethrpctest/CMakeLists.txt
@@ -9,7 +9,8 @@ file(GLOB HEADERS "*.h")
 
 add_executable(${EXECUTABLE} ${SRC_LIST} ${HEADERS})
 
-eth_use(${EXECUTABLE} REQUIRED Web3::web3jsonrpc Eth::testutils JsonRpc::Client)
+set(ETHASHCL 1)
+eth_use(${EXECUTABLE} REQUIRED Web3::web3jsonrpc Eth::testutils JsonRpc::Client Eth::ethash-cl)
 target_link_libraries(${EXECUTABLE} ${Boost_PROGRAM_OPTIONS_LIBRARY})
 target_link_libraries(${EXECUTABLE} web3testutils)
 


### PR DESCRIPTION
In a Windows split repos build we are getting unresolved external symbols
for libethash-cl related code and hence the build fails.

With this PR I am adding the ethash-cl dependency where required.
