### PR TITLE
default options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,10 @@ include(EthExecutableHelper)
 # Include utils
 include(EthUtils)
 
+include(EthOptions)
+configure_project()
+print_config()
+
 # libraries
 add_subdirectory(libwebthree)
 add_subdirectory(libweb3jsonrpc)


### PR DESCRIPTION
It was my bad, webthree was missing default cmake options. It fixes https://github.com/ethereum/webthree-helpers/pull/11
