### PR TITLE
Fix web3.admin.exit() by nonblocking socket

### DIFF
--- a/libweb3jsonrpc/UnixSocketServer.cpp
+++ b/libweb3jsonrpc/UnixSocketServer.cpp
@@ -62,7 +62,7 @@ bool UnixDomainSocketServer::StartListening()
 		if (access(m_path.c_str(), F_OK) != -1)
 			return false;
 
-		m_socket = socket(PF_UNIX, SOCK_STREAM, 0);
+		m_socket = socket(PF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0);
 		memset(&(m_address), 0, sizeof(sockaddr_un));
 		m_address.sun_family = AF_UNIX;
 #ifdef __APPLE__


### PR DESCRIPTION
The reason `web3.admin.exit()` was not working is that the ipc server
listening thread was never finishing due to a race condition between the
`Unixdomainsocketserver::Listen()` function and the
`IpcServerbase::StopListening()` function.

Basically `IpcServerbase` was stuck at `m_listeningThread.join()` waiting
for the socket to accept a connection which would not happen since we
have already closed them all and are on the freeing/destruction path.

Making the socket non-blocking solves the problem but I would like input
from @arkpar if this is the "right" way to handle this.
