### PR TITLE
Fix windows build - no uint in windows

### DIFF
--- a/libweb3jsonrpc/WebThreeStubServerBase.cpp
+++ b/libweb3jsonrpc/WebThreeStubServerBase.cpp
@@ -83,7 +83,7 @@ string WebThreeStubServerBase::web3_sha3(string const& _param1)
 
 string WebThreeStubServerBase::net_version()
 {
-	return toJS((uint)c_network);
+	return toJS((unsigned)c_network);
 }
 
 string WebThreeStubServerBase::net_peerCount()


### PR DESCRIPTION
Just noticed it that in Jenkins the Windows build [is failing](http://52.28.164.97/job/project-build/684/label=windows-slave/console). This should fix it.

```
       (ClCompile target) -> 
         C:\Jenkins\sharedspace\webthree-helpers\label\windows-slave\webthree\libweb3jsonrpc\WebThreeStubServerBase.cpp(86): error C2065: 'uint' : undeclared identifier [C:\Jenkins\sharedspace\webthree-helpers\label\windows-slave\webthree\build\libweb3jsonrpc\web3jsonrpc.vcxproj]
         C:\Jenkins\sharedspace\webthree-helpers\label\windows-slave\webthree\libweb3jsonrpc\WebThreeStubServerBase.cpp(86): error C2146: syntax error : missing ')' before identifier 'c_network' [C:\Jenkins\sharedspace\webthree-helpers\label\windows-slave\webthree\build\libweb3jsonrpc\web3jsonrpc.vcxproj]
         C:\Jenkins\sharedspace\webthree-helpers\label\windows-slave\webthree\libweb3jsonrpc\WebThreeStubServerBase.cpp(86): error C2059: syntax error : ')' [C:\Jenkins\sharedspace\webthree-helpers\label\windows-slave\webthree\build\libweb3jsonrpc\web3jsonrpc.vcxproj]

    0 Warning(s)
    3 Error(s)
```
