### PR TITLE
jsonrpc modules

### DIFF
--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -1206,8 +1206,6 @@ int main(int argc, char** argv)
 		if (useConsole)
 		{
 #if ETH_JSCONSOLE || !ETH_TRUE
-			
-			// TODO: ownership of connector
 			JSLocalConsole console;
 			dev::WebThreeStubServer* webthreeFace = new dev::WebThreeStubServer(web3, make_shared<SimpleAccountHolder>([&](){ return web3.ethereum(); }, getAccountPassword, keyManager), vector<KeyPair>(), keyManager, *gasPricer);
 			ModularServer<dev::WebThreeStubServer> rpcServer(webthreeFace);

--- a/libjsconsole/JSLocalConsole.cpp
+++ b/libjsconsole/JSLocalConsole.cpp
@@ -20,15 +20,5 @@
  * Ethereum client.
  */
 
-#include <iostream>
 #include "JSLocalConsole.h"
-#include "JSV8Connector.h"
 
-using namespace std;
-using namespace dev;
-using namespace dev::eth;
-
-JSLocalConsole::JSLocalConsole()
-{
-	m_jsonrpcConnector.reset(new JSV8Connector(m_engine));
-}

--- a/libjsconsole/JSLocalConsole.h
+++ b/libjsconsole/JSLocalConsole.h
@@ -25,6 +25,7 @@
 #include <libjsengine/JSV8Engine.h>
 #include <libjsengine/JSV8Printer.h>
 #include "JSConsole.h"
+#include "JSV8Connector.h"
 
 class WebThreeStubServer;
 namespace jsonrpc { class AbstractServerConnector; }
@@ -37,13 +38,8 @@ namespace eth
 class JSLocalConsole: public JSConsole<JSV8Engine, JSV8Printer>
 {
 public:
-	JSLocalConsole();
 	virtual ~JSLocalConsole() {}
-
-	jsonrpc::AbstractServerConnector* connector() { return m_jsonrpcConnector.get(); }
-
-private:
-	std::unique_ptr<jsonrpc::AbstractServerConnector> m_jsonrpcConnector;
+	jsonrpc::AbstractServerConnector* createConnector() { return new JSV8Connector(m_engine); }
 };
 
 }

--- a/libweb3jsonrpc/AbstractWebThreeStubServer.h
+++ b/libweb3jsonrpc/AbstractWebThreeStubServer.h
@@ -5,12 +5,12 @@
 #ifndef JSONRPC_CPP_STUB_ABSTRACTWEBTHREESTUBSERVER_H_
 #define JSONRPC_CPP_STUB_ABSTRACTWEBTHREESTUBSERVER_H_
 
-#include <jsonrpccpp/server.h>
+#include "ModularServer.h"
 
-class AbstractWebThreeStubServer : public jsonrpc::AbstractServer<AbstractWebThreeStubServer>
+class AbstractWebThreeStubServer : public ServerInterface<AbstractWebThreeStubServer>
 {
     public:
-        AbstractWebThreeStubServer(jsonrpc::AbstractServerConnector &conn, jsonrpc::serverVersion_t type = jsonrpc::JSONRPC_SERVER_V2) : jsonrpc::AbstractServer<AbstractWebThreeStubServer>(conn, type)
+        AbstractWebThreeStubServer()
         {
             this->bindAndAddMethod(jsonrpc::Procedure("web3_sha3", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::web3_sha3I);
             this->bindAndAddMethod(jsonrpc::Procedure("web3_clientVersion", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING,  NULL), &AbstractWebThreeStubServer::web3_clientVersionI);

--- a/libweb3jsonrpc/ModularServer.h
+++ b/libweb3jsonrpc/ModularServer.h
@@ -59,6 +59,8 @@ public:
 	ModularServer()
 	: m_handler(jsonrpc::RequestHandlerFactory::createProtocolHandler(jsonrpc::JSONRPC_SERVER_V2, *this)) {}
 
+	virtual ~ModularServer() { StopListening(); }
+
 	virtual void StartListening()
 	{
 		for (auto const& connector: m_connectors)

--- a/libweb3jsonrpc/ModularServer.h
+++ b/libweb3jsonrpc/ModularServer.h
@@ -1,0 +1,122 @@
+#pragma once
+
+#include <string>
+#include <map>
+#include <vector>
+#include <jsonrpccpp/common/procedure.h>
+#include <jsonrpccpp/server/iprocedureinvokationhandler.h>
+#include <jsonrpccpp/server/abstractserverconnector.h>
+#include <jsonrpccpp/server/requesthandlerfactory.h>
+
+template <class I> using AbstractMethodPointer = void(I::*)(Json::Value const& _parameter, Json::Value& _result);
+template <class I> using AbstractNotificationPointer = void(I::*)(Json::Value const& _parameter);
+
+template <template <class I> class C, class I>
+class ProcedureBinding
+{
+public:
+	using CallPointer = C<I>;
+
+	ProcedureBinding(jsonrpc::Procedure const& _procedure, CallPointer _call)
+	: m_procedure(_procedure), m_call(_call) {}
+
+	jsonrpc::Procedure const& procedure() const { return m_procedure; }
+	CallPointer call() const { return m_call; }
+
+private:
+	jsonrpc::Procedure m_procedure;
+	CallPointer m_call;
+};
+
+template <class I> using MethodBinding = ProcedureBinding<AbstractMethodPointer, I>;
+template <class I> using NotificationBinding = ProcedureBinding<AbstractNotificationPointer, I>;
+
+template <class I>
+class ServerInterface
+{
+public:
+	using MethodPointer = AbstractMethodPointer<I>;
+	using NotificationPointer = AbstractNotificationPointer<I>;
+	using Methods = std::vector<MethodBinding<I>>;
+	using Notifications = std::vector<NotificationBinding<I>>;
+
+	Methods const& methods() const { return m_methods; }
+	Notifications const& notifications() const { return m_notifications; }
+
+protected:
+	void bindAndAddMethod(jsonrpc::Procedure const& _proc, MethodPointer _pointer) { m_methods.emplace_back(_proc, _pointer); }
+	void bindAndAddNotification(jsonrpc::Procedure const& _proc, NotificationPointer _pointer) { m_notifications.emplace_back(_proc, _pointer); }
+
+private:
+	Methods m_methods;
+	Notifications m_notifications;
+};
+
+template <class... Is>
+class ModularServer: public jsonrpc::IProcedureInvokationHandler
+{
+public:
+	ModularServer(jsonrpc::AbstractServerConnector* _connector)
+	: m_connection(_connector), m_handler(jsonrpc::RequestHandlerFactory::createProtocolHandler(jsonrpc::JSONRPC_SERVER_V2, *this))
+	{
+		m_connection->SetHandler(m_handler.get());
+	}
+
+	bool StartListening() { return m_connection->StartListening(); }
+	bool StopListening() { return m_connection->StopListening(); }
+
+	virtual void HandleMethodCall(jsonrpc::Procedure& _proc, const Json::Value& _input, Json::Value& _output) override {}
+	virtual void HandleNotificationCall(jsonrpc::Procedure& _proc, const Json::Value& _input) override {}
+
+private:
+	std::unique_ptr<jsonrpc::AbstractServerConnector> m_connection;
+
+protected:
+	std::unique_ptr<jsonrpc::IProtocolHandler> m_handler;
+};
+
+template <class I, class... Is>
+class ModularServer<I, Is...> : public ModularServer<Is...>
+{
+public:
+	using MethodPointer = AbstractMethodPointer<I>;
+	using NotificationPointer = AbstractNotificationPointer<I>;
+
+	ModularServer<I, Is...>(jsonrpc::AbstractServerConnector* _connector, I* _i, Is*... _is): ModularServer<Is...>(_connector, _is...), m_interface(_i)
+	{
+		for (auto const& method: m_interface->methods())
+		{
+			m_methods[method.procedure().GetProcedureName()] = method.call();
+			this->m_handler->AddProcedure(method.procedure());
+		}
+		
+		for (auto const& notification: m_interface->notifications())
+		{
+			m_notifications[notification.procedure().GetProcedureName()] = notification.call();
+			this->m_handler->AddProcedure(notification.procedure());
+		}
+	}
+
+	virtual void HandleMethodCall(jsonrpc::Procedure& _proc, const Json::Value& _input, Json::Value& _output) override
+	{
+		auto pointer = m_methods.find(_proc.GetProcedureName());
+		if (pointer != m_methods.end())
+			(m_interface.get()->*(pointer->second))(_input, _output);
+		else
+			ModularServer<Is...>::HandleMethodCall(_proc, _input, _output);
+	}
+
+	virtual void HandleNotificationCall(jsonrpc::Procedure& _proc, const Json::Value& _input) override
+	{
+		auto pointer = m_notifications.find(_proc.GetProcedureName());
+		if (pointer != m_notifications.end())
+			(m_interface.get()->*(pointer->second))(_input);
+		else
+			ModularServer<Is...>::HandleNotificationCall(_proc, _input);
+	}
+
+private:
+	std::unique_ptr<I> m_interface;
+	std::map<std::string, MethodPointer> m_methods;
+	std::map<std::string, NotificationPointer> m_notifications;
+};

--- a/libweb3jsonrpc/ModularServer.h
+++ b/libweb3jsonrpc/ModularServer.h
@@ -56,21 +56,47 @@ template <class... Is>
 class ModularServer: public jsonrpc::IProcedureInvokationHandler
 {
 public:
-	ModularServer(jsonrpc::AbstractServerConnector* _connector)
-	: m_connection(_connector), m_handler(jsonrpc::RequestHandlerFactory::createProtocolHandler(jsonrpc::JSONRPC_SERVER_V2, *this))
+	ModularServer()
+	: m_handler(jsonrpc::RequestHandlerFactory::createProtocolHandler(jsonrpc::JSONRPC_SERVER_V2, *this)) {}
+
+	virtual void StartListening()
 	{
-		m_connection->SetHandler(m_handler.get());
+		for (auto const& connector: m_connectors)
+			connector->StartListening();
+	}
+	
+	virtual void StopListening()
+	{
+		for (auto const& connector: m_connectors)
+			connector->StopListening();
 	}
 
-	bool StartListening() { return m_connection->StartListening(); }
-	bool StopListening() { return m_connection->StopListening(); }
+	virtual void HandleMethodCall(jsonrpc::Procedure& _proc, Json::Value const& _input, Json::Value& _output) override
+	{
+		(void)_proc;
+		(void)_input;
+		(void)_output;
+	}
 
-	virtual void HandleMethodCall(jsonrpc::Procedure& _proc, const Json::Value& _input, Json::Value& _output) override {}
-	virtual void HandleNotificationCall(jsonrpc::Procedure& _proc, const Json::Value& _input) override {}
+	virtual void HandleNotificationCall(jsonrpc::Procedure& _proc, Json::Value const& _input) override
+	{
+		(void)_proc;
+		(void)_input;
+	}
 
-private:
-	std::unique_ptr<jsonrpc::AbstractServerConnector> m_connection;
+	unsigned addConnector(jsonrpc::AbstractServerConnector* _connector)
+	{
+		m_connectors.emplace_back(_connector);
+		_connector->SetHandler(m_handler.get());
+		return m_connectors.size() - 1;
+	}
+
+	jsonrpc::AbstractServerConnector* connector(unsigned _i) const {
+		return m_connectors.at(_i).get();
+	}
+
 protected:
+	std::vector<std::unique_ptr<jsonrpc::AbstractServerConnector>> m_connectors;
 	std::unique_ptr<jsonrpc::IProtocolHandler> m_handler;
 };
 
@@ -81,7 +107,7 @@ public:
 	using MethodPointer = AbstractMethodPointer<I>;
 	using NotificationPointer = AbstractNotificationPointer<I>;
 
-	ModularServer<I, Is...>(jsonrpc::AbstractServerConnector* _connector, I* _i, Is*... _is): ModularServer<Is...>(_connector, _is...), m_interface(_i)
+	ModularServer<I, Is...>(I* _i, Is*... _is): ModularServer<Is...>(_is...), m_interface(_i)
 	{
 		for (auto const& method: m_interface->methods())
 		{
@@ -96,7 +122,7 @@ public:
 		}
 	}
 
-	virtual void HandleMethodCall(jsonrpc::Procedure& _proc, const Json::Value& _input, Json::Value& _output) override
+	virtual void HandleMethodCall(jsonrpc::Procedure& _proc, Json::Value const& _input, Json::Value& _output) override
 	{
 		auto pointer = m_methods.find(_proc.GetProcedureName());
 		if (pointer != m_methods.end())
@@ -105,7 +131,7 @@ public:
 			ModularServer<Is...>::HandleMethodCall(_proc, _input, _output);
 	}
 
-	virtual void HandleNotificationCall(jsonrpc::Procedure& _proc, const Json::Value& _input) override
+	virtual void HandleNotificationCall(jsonrpc::Procedure& _proc, Json::Value const& _input) override
 	{
 		auto pointer = m_notifications.find(_proc.GetProcedureName());
 		if (pointer != m_notifications.end())

--- a/libweb3jsonrpc/ModularServer.h
+++ b/libweb3jsonrpc/ModularServer.h
@@ -93,7 +93,8 @@ public:
 		return m_connectors.size() - 1;
 	}
 
-	jsonrpc::AbstractServerConnector* connector(unsigned _i) const {
+	jsonrpc::AbstractServerConnector* connector(unsigned _i) const
+	{
 		return m_connectors.at(_i).get();
 	}
 

--- a/libweb3jsonrpc/ModularServer.h
+++ b/libweb3jsonrpc/ModularServer.h
@@ -70,7 +70,6 @@ public:
 
 private:
 	std::unique_ptr<jsonrpc::AbstractServerConnector> m_connection;
-
 protected:
 	std::unique_ptr<jsonrpc::IProtocolHandler> m_handler;
 };

--- a/libweb3jsonrpc/RPCServer.h
+++ b/libweb3jsonrpc/RPCServer.h
@@ -1,0 +1,39 @@
+#pragma once
+#include "SafeHttpServer.h"
+#include "ModularServer.h"
+#include "IpcServer.h"
+
+template <class I, class... Is>
+class RPCServer: public ModularServer<I, Is...>
+{
+public:
+	RPCServer<I, Is...>(I* _i, Is*... _is): ModularServer<I, Is...>(_i, _is...)
+	{
+		// todo: use sensible***
+		m_httpConnectorId = this->addConnector(new dev::SafeHttpServer(8545, "", "", 4));
+		m_ipcConnectorId = this->addConnector(new dev::IpcServer("geth"));
+	}
+
+	void enableHttp(bool _enabled)
+	{
+		if (_enabled)
+			httpConnector()->StartListening();
+		else
+			httpConnector()->StopListening();
+	}
+
+	void enableIpc(bool _enabled)
+	{
+		if (_enabled)
+			ipcConnector()->StartListening();
+		else
+			ipcConnector()->StopListening();
+	}
+
+	dev::SafeHttpServer* httpConnector() const { return static_cast<dev::SafeHttpServer*>(this->connector(m_httpConnectorId)); }
+	dev::IpcServer* ipcConnector() const { return static_cast<dev::IpcServer*>(this->connector(m_ipcConnectorId)); }
+
+private:
+	unsigned m_httpConnectorId;
+	unsigned m_ipcConnectorId;
+};

--- a/libweb3jsonrpc/WebThreeStubServer.cpp
+++ b/libweb3jsonrpc/WebThreeStubServer.cpp
@@ -52,8 +52,8 @@ template <class T> bool isHash(std::string const& _hash)
 	return (_hash.size() == T::size * 2 || (_hash.size() == T::size * 2 + 2 && _hash.substr(0, 2) == "0x")) && isHex(_hash);
 }
 
-WebThreeStubServer::WebThreeStubServer(jsonrpc::AbstractServerConnector& _conn, WebThreeDirect& _web3, shared_ptr<AccountHolder> const& _ethAccounts, std::vector<dev::KeyPair> const& _shhAccounts, KeyManager& _keyMan, dev::eth::TrivialGasPricer& _gp):
-	WebThreeStubServerBase(_conn, _ethAccounts, _shhAccounts),
+WebThreeStubServer::WebThreeStubServer(WebThreeDirect& _web3, shared_ptr<AccountHolder> const& _ethAccounts, std::vector<dev::KeyPair> const& _shhAccounts, KeyManager& _keyMan, dev::eth::TrivialGasPricer& _gp):
+	WebThreeStubServerBase(_ethAccounts, _shhAccounts),
 	m_web3(_web3),
 	m_keyMan(_keyMan),
 	m_gp(_gp)

--- a/libweb3jsonrpc/WebThreeStubServer.h
+++ b/libweb3jsonrpc/WebThreeStubServer.h
@@ -49,7 +49,7 @@ struct SessionPermissions
 class WebThreeStubServer: public dev::WebThreeStubServerBase, public dev::WebThreeStubDatabaseFace
 {
 public:
-	WebThreeStubServer(jsonrpc::AbstractServerConnector& _conn, dev::WebThreeDirect& _web3, std::shared_ptr<dev::eth::AccountHolder> const& _ethAccounts, std::vector<dev::KeyPair> const& _shhAccounts, dev::eth::KeyManager& _keyMan, dev::eth::TrivialGasPricer& _gp);
+	WebThreeStubServer(dev::WebThreeDirect& _web3, std::shared_ptr<dev::eth::AccountHolder> const& _ethAccounts, std::vector<dev::KeyPair> const& _shhAccounts, dev::eth::KeyManager& _keyMan, dev::eth::TrivialGasPricer& _gp);
 
 	virtual std::string web3_clientVersion() override;
 

--- a/libweb3jsonrpc/WebThreeStubServerBase.cpp
+++ b/libweb3jsonrpc/WebThreeStubServerBase.cpp
@@ -62,10 +62,11 @@ const unsigned dev::SensibleHttpThreads = 4;
 #endif
 const unsigned dev::SensibleHttpPort = 8545;
 
-WebThreeStubServerBase::WebThreeStubServerBase(AbstractServerConnector& _conn, std::shared_ptr<dev::eth::AccountHolder> const& _ethAccounts, vector<dev::KeyPair> const& _sshAccounts):
-	AbstractWebThreeStubServer(_conn),
-	m_ethAccounts(_ethAccounts),
-	m_handler(_conn.GetHandler())
+WebThreeStubServerBase::WebThreeStubServerBase(std::shared_ptr<dev::eth::AccountHolder> const& _ethAccounts, vector<dev::KeyPair> const& _sshAccounts):
+	AbstractWebThreeStubServer(),
+	m_ethAccounts(_ethAccounts)
+// TODO: fix this!
+//	m_handler(_conn.GetHandler())
 {
 	setIdentities(_sshAccounts);
 }

--- a/libweb3jsonrpc/WebThreeStubServerBase.cpp
+++ b/libweb3jsonrpc/WebThreeStubServerBase.cpp
@@ -65,8 +65,6 @@ const unsigned dev::SensibleHttpPort = 8545;
 WebThreeStubServerBase::WebThreeStubServerBase(std::shared_ptr<dev::eth::AccountHolder> const& _ethAccounts, vector<dev::KeyPair> const& _sshAccounts):
 	AbstractWebThreeStubServer(),
 	m_ethAccounts(_ethAccounts)
-// TODO: fix this!
-//	m_handler(_conn.GetHandler())
 {
 	setIdentities(_sshAccounts);
 }
@@ -1017,20 +1015,5 @@ Json::Value WebThreeStubServerBase::shh_getMessages(string const& _filterId)
 	catch (...)
 	{
 		BOOST_THROW_EXCEPTION(JsonRpcException(Errors::ERROR_RPC_INVALID_PARAMS));
-	}
-}
-
-void WebThreeStubServerBase::enableIpc(bool _enable)
-{
-	if (_enable && !m_ipcConnector)
-	{
-		m_ipcConnector.reset(new IpcServer("geth"));
-		m_ipcConnector->SetHandler(m_handler);
-		m_ipcConnector->StartListening();
-	}
-	else if (!_enable && m_ipcConnector.get())
-	{
-		m_ipcConnector->StopListening();
-		m_ipcConnector.reset();
 	}
 }

--- a/libweb3jsonrpc/WebThreeStubServerBase.h
+++ b/libweb3jsonrpc/WebThreeStubServerBase.h
@@ -198,9 +198,6 @@ public:
 	virtual std::string personal_newAccount(const std::string&) { return ""; }
 	virtual bool personal_unlockAccount(const std::string&, const std::string&, int) { return false; }
 
-	// IPC connector
-	void enableIpc(bool _enable);
-
 	// TODO REMOVE
 	virtual bool admin_eth_setReferencePrice(std::string const& _wei, std::string const& _session) { (void)_wei; (void)_session; return false; }
 	virtual bool admin_eth_setPriority(int _percent, std::string const& _session) { (void)_percent; (void)_session; return false; }
@@ -224,9 +221,6 @@ protected:
 
 	std::map<dev::Public, dev::Secret> m_shhIds;
 	std::map<unsigned, dev::Public> m_shhWatches;
-
-	std::unique_ptr<jsonrpc::AbstractServerConnector> m_ipcConnector;
-	jsonrpc::IClientConnectionHandler* m_handler;
 };
 
 } //namespace dev

--- a/libweb3jsonrpc/WebThreeStubServerBase.h
+++ b/libweb3jsonrpc/WebThreeStubServerBase.h
@@ -91,7 +91,7 @@ namespace dev
 class WebThreeStubServerBase: public AbstractWebThreeStubServer
 {
 public:
-	WebThreeStubServerBase(jsonrpc::AbstractServerConnector& _conn, std::shared_ptr<dev::eth::AccountHolder> const& _ethAccounts, std::vector<dev::KeyPair> const& _sshAccounts);
+	WebThreeStubServerBase(std::shared_ptr<dev::eth::AccountHolder> const& _ethAccounts, std::vector<dev::KeyPair> const& _sshAccounts);
 
 	std::shared_ptr<dev::eth::AccountHolder> const& ethAccounts() const { return m_ethAccounts; }
 

--- a/test/ethrpctest/CommandLineInterface.cpp
+++ b/test/ethrpctest/CommandLineInterface.cpp
@@ -29,6 +29,7 @@
 #include <libtestutils/Common.h>
 #include <libtestutils/BlockChainLoader.h>
 #include <libtestutils/FixedClient.h>
+#include <libweb3jsonrpc/ModularServer.h>
 #include <libweb3testutils/FixedWebThreeServer.h>
 #include "CommandLineInterface.h"
 
@@ -115,11 +116,10 @@ void CommandLineInterface::actOnInput()
 	BlockChainLoader bcl(m_json);
 	cerr << "void CommandLineInterface::actOnInput() FixedClient now accepts eth::Block!!!" << endl;
 	FixedClient client(bcl.bc(), eth::Block{}/*bcl.state()*/);
-	unique_ptr<FixedWebThreeServer> jsonrpcServer;
-	auto server = new jsonrpc::HttpServer(8080, "", "", 2);
-	jsonrpcServer.reset(new FixedWebThreeServer(*server, {}, &client));
-	jsonrpcServer->StartListening();
-
+	ModularServer<FixedWebThreeServer> server(new FixedWebThreeServer({}, &client));
+	server.addConnector(new jsonrpc::HttpServer(8080, "", "", 2));
+	server.StartListening();
+	
 	signal(SIGABRT, &sighandler);
 	signal(SIGTERM, &sighandler);
 	signal(SIGINT, &sighandler);

--- a/test/libweb3testutils/FixedWebThreeServer.h
+++ b/test/libweb3testutils/FixedWebThreeServer.h
@@ -34,8 +34,8 @@
 class FixedWebThreeServer: public dev::WebThreeStubServerBase, public dev::WebThreeStubDatabaseFace
 {
 public:
-	FixedWebThreeServer(jsonrpc::AbstractServerConnector& _conn, std::vector<dev::KeyPair> const& _allAccounts, dev::eth::Interface* _client):
-		WebThreeStubServerBase(_conn, std::make_shared<dev::eth::FixedAccountHolder>([=](){return _client;}, _allAccounts), _allAccounts),
+	FixedWebThreeServer(std::vector<dev::KeyPair> const& _allAccounts, dev::eth::Interface* _client):
+		WebThreeStubServerBase(std::make_shared<dev::eth::FixedAccountHolder>([=](){return _client;}, _allAccounts), _allAccounts),
 		m_client(_client)
 	{}
 


### PR DESCRIPTION
part of changes required for modularization of jsonrpc

based on:
- https://github.com/ethereum/webthree-helpers/pull/57

**changes:**

ModularServer class. It allows to create one server using multiple interfaces. In future, when we finish splitting jsonrpc server, it could be used like:

``` c++
{
  ModularServer<Eth, Shh, Net, Db, Admin> server(new Eth(), new Shh(), new Net() new LevelDBFace(), new Admin());
  server.addConnector(new SafeHttpConnector());
  server.addConnector(new IpcConnector());
  server.startListening();
}
```

where Eth, Shh, Net and Admin interfaces can be generated using their own .json files.

I also started applying some name convention to web3jsonrpc classes. From now on, I will try to make all names correctly describe classes, so we could distinguish what is:
- connector (IpcConnector, HttpConnector)
- interface/face (now only WebThreeFace, in next prs: Eth, Shh, Net, Admin)
- server (ModularServer)
