### PR TITLE
Remove setMineOnBadChain() call

### DIFF
--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -969,7 +969,6 @@ int main(int argc, char** argv)
 		nodeMode == NodeMode::Full ? caps : set<string>(),
 		netPrefs,
 		&nodesState);
-	web3.ethereum()->setMineOnBadChain(mineOnWrongChain);
 	web3.ethereum()->setSentinel(sentinel);
 	if (!extraData.empty())
 		web3.ethereum()->setExtraData(extraData);


### PR DESCRIPTION
It seems that web3.ethereum()->setSealOnBadChain() was also removed
by commit:
https://github.com/ethereum/libethereum/commit/c6e92a8f943180e0d48c87568edce348695e352a
and as such this call no longer makes sense.
