### PR TITLE
Enable the usage of Solidity from ++eth

### DIFF
--- a/libweb3jsonrpc/CMakeLists.txt
+++ b/libweb3jsonrpc/CMakeLists.txt
@@ -7,6 +7,7 @@ file(GLOB HEADERS "*.h")
 add_library(${EXECUTABLE} ${SRC_LIST} ${HEADERS})
 
 eth_use(${EXECUTABLE} REQUIRED Web3::whisper Web3::webthree JsonRpc::Server)
+eth_use(${EXECUTABLE} OPTIONAL Solidity)
 
 jsonrpcstub_create(eth.json 
 	dev::rpc::EthFace ${CMAKE_CURRENT_SOURCE_DIR} EthFace 


### PR DESCRIPTION
With this javascript's API

``` js
we3.eth.compile.solidity('bla')
```

will work again
