### PR TITLE
Added missing #ifdefs to eth and flu main.cpp files

### DIFF
--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -880,17 +880,17 @@ int main(int argc, char** argv)
 		}
 	}
 
-#if ETH_JSCONSOLE || !ETH_TRUE
 	if (mode == OperationMode::Attach)
 	{
+#if ETH_JSCONSOLE || !ETH_TRUE
 		JSRemoteConsole console(remoteURL);
 		if (!remoteSessionKey.empty())
 			console.eval("web3.admin.setSessionKey('" + remoteSessionKey + "')");
 		while (true)
 			console.readAndEval();
+#endif
 		return 0;
 	}
-#endif
 
 	// Set up all the chain config stuff.
 	if (!paramsJSON.empty())

--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -880,6 +880,7 @@ int main(int argc, char** argv)
 		}
 	}
 
+#if ETH_JSCONSOLE || !ETH_TRUE
 	if (mode == OperationMode::Attach)
 	{
 		JSRemoteConsole console(remoteURL);
@@ -889,6 +890,7 @@ int main(int argc, char** argv)
 			console.readAndEval();
 		return 0;
 	}
+#endif
 
 	// Set up all the chain config stuff.
 	if (!paramsJSON.empty())

--- a/flu/MainCLI.cpp
+++ b/flu/MainCLI.cpp
@@ -135,6 +135,7 @@ void MainCLI::execute()
 	case Mode::Attach:
 	case Mode::Execute:
 	{
+#if ETH_JSCONSOLE || !ETH_TRUE
 		JSRemoteConsole console(m_remoteURL);
 		if (m_mode == Mode::Attach)
 		{
@@ -168,6 +169,7 @@ void MainCLI::execute()
 					console.eval(c.empty() ? i : c);
 				}
 		}
+#endif
 		break;
 	}
 	case Mode::Console:


### PR DESCRIPTION
Added missing #ifdefs to eth and flu main.cpp files, both of which contained unconditional use of the JSRemoteConsole class even when JSCONSOLE is disabled.
