### PR TITLE
Implement personal.unlockAccount

### DIFF
--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -1186,6 +1186,7 @@ int main(int argc, char** argv)
 	AddressHash allowedDestinations;
 
 	auto authenticator = [&](TransactionSkeleton const& _t, bool isProxy) -> bool {
+		// "unlockAccount" functionality is done in the AccountHolder.
 		if (!alwaysConfirm || allowedDestinations.count(_t.to))
 			return true;
 
@@ -1214,7 +1215,7 @@ int main(int argc, char** argv)
 		auto adminEthFace = new rpc::AdminEth(*web3.ethereum(), *gasPricer.get(), keyManager, *sessionManager.get());
 		jsonrpcServer.reset(new ModularServer<rpc::EthFace, rpc::DBFace, rpc::WhisperFace,
 							rpc::NetFace, rpc::Web3Face, rpc::PersonalFace,
-							rpc::AdminEthFace, rpc::AdminNetFace, rpc::AdminUtilsFace>(ethFace, new rpc::LevelDB(), new rpc::Whisper(web3, {}), new rpc::Net(web3), new rpc::Web3(web3.clientVersion()), new rpc::Personal(keyManager), adminEthFace, new rpc::AdminNet(web3, *sessionManager.get()), new rpc::AdminUtils(*sessionManager.get(), &exitHandler)));
+							rpc::AdminEthFace, rpc::AdminNetFace, rpc::AdminUtilsFace>(ethFace, new rpc::LevelDB(), new rpc::Whisper(web3, {}), new rpc::Net(web3), new rpc::Web3(web3.clientVersion()), new rpc::Personal(keyManager, *accountHolder), adminEthFace, new rpc::AdminNet(web3, *sessionManager.get()), new rpc::AdminUtils(*sessionManager.get(), &exitHandler)));
 		if (jsonRPCURL > -1)
 		{
 			auto httpConnector = new SafeHttpServer(jsonRPCURL, "", "", SensibleHttpThreads);
@@ -1274,7 +1275,7 @@ int main(int argc, char** argv)
 			auto adminNetFace = new rpc::AdminNet(web3, sessionManager);
 			auto adminUtilsFace = new rpc::AdminUtils(sessionManager);
 			
-			ModularServer<rpc::EthFace, rpc::DBFace, rpc::WhisperFace, rpc::NetFace, rpc::Web3Face, rpc::PersonalFace, rpc::AdminEthFace, rpc::AdminNetFace, rpc::AdminUtilsFace> rpcServer(ethFace, new rpc::LevelDB(), new rpc::Whisper(web3, {}), new rpc::Net(web3), new rpc::Web3(web3.clientVersion()), new rpc::Personal(keyManager), adminEthFace, adminNetFace, adminUtilsFace);
+			ModularServer<rpc::EthFace, rpc::DBFace, rpc::WhisperFace, rpc::NetFace, rpc::Web3Face, rpc::PersonalFace, rpc::AdminEthFace, rpc::AdminNetFace, rpc::AdminUtilsFace> rpcServer(ethFace, new rpc::LevelDB(), new rpc::Whisper(web3, {}), new rpc::Net(web3), new rpc::Web3(web3.clientVersion()), new rpc::Personal(keyManager, accountHolder), adminEthFace, adminNetFace, adminUtilsFace);
 
 			JSLocalConsole console;
 			rpcServer.addConnector(console.createConnector());

--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -1213,9 +1213,16 @@ int main(int argc, char** argv)
 		accountHolder.reset(new SimpleAccountHolder([&](){ return web3.ethereum(); }, getAccountPassword, keyManager, authenticator));
 		auto ethFace = new rpc::Eth(*web3.ethereum(), *accountHolder.get());
 		auto adminEthFace = new rpc::AdminEth(*web3.ethereum(), *gasPricer.get(), keyManager, *sessionManager.get());
-		jsonrpcServer.reset(new ModularServer<rpc::EthFace, rpc::DBFace, rpc::WhisperFace,
-							rpc::NetFace, rpc::Web3Face, rpc::PersonalFace,
-							rpc::AdminEthFace, rpc::AdminNetFace, rpc::AdminUtilsFace>(ethFace, new rpc::LevelDB(), new rpc::Whisper(web3, {}), new rpc::Net(web3), new rpc::Web3(web3.clientVersion()), new rpc::Personal(keyManager, *accountHolder), adminEthFace, new rpc::AdminNet(web3, *sessionManager.get()), new rpc::AdminUtils(*sessionManager.get(), &exitHandler)));
+		jsonrpcServer.reset(new ModularServer<
+			rpc::EthFace, rpc::DBFace, rpc::WhisperFace,
+			rpc::NetFace, rpc::Web3Face, rpc::PersonalFace,
+			rpc::AdminEthFace, rpc::AdminNetFace, rpc::AdminUtilsFace
+		>(
+			ethFace, new rpc::LevelDB(), new rpc::Whisper(web3, {}),
+			new rpc::Net(web3), new rpc::Web3(web3.clientVersion()), new rpc::Personal(keyManager, *accountHolder),
+			adminEthFace, new rpc::AdminNet(web3, *sessionManager.get()),
+			new rpc::AdminUtils(*sessionManager.get(), &exitHandler)
+		));
 		if (jsonRPCURL > -1)
 		{
 			auto httpConnector = new SafeHttpServer(jsonRPCURL, "", "", SensibleHttpThreads);
@@ -1275,7 +1282,15 @@ int main(int argc, char** argv)
 			auto adminNetFace = new rpc::AdminNet(web3, sessionManager);
 			auto adminUtilsFace = new rpc::AdminUtils(sessionManager);
 			
-			ModularServer<rpc::EthFace, rpc::DBFace, rpc::WhisperFace, rpc::NetFace, rpc::Web3Face, rpc::PersonalFace, rpc::AdminEthFace, rpc::AdminNetFace, rpc::AdminUtilsFace> rpcServer(ethFace, new rpc::LevelDB(), new rpc::Whisper(web3, {}), new rpc::Net(web3), new rpc::Web3(web3.clientVersion()), new rpc::Personal(keyManager, accountHolder), adminEthFace, adminNetFace, adminUtilsFace);
+			ModularServer<
+				rpc::EthFace, rpc::DBFace, rpc::WhisperFace,
+				rpc::NetFace, rpc::Web3Face, rpc::PersonalFace,
+				rpc::AdminEthFace, rpc::AdminNetFace, rpc::AdminUtilsFace
+			> rpcServer(
+				ethFace, new rpc::LevelDB(), new rpc::Whisper(web3, {}),
+				new rpc::Net(web3), new rpc::Web3(web3.clientVersion()), new rpc::Personal(keyManager, accountHolder),
+				adminEthFace, adminNetFace, adminUtilsFace
+			);
 
 			JSLocalConsole console;
 			rpcServer.addConnector(console.createConnector());

--- a/flu/MainCLI.cpp
+++ b/flu/MainCLI.cpp
@@ -246,7 +246,7 @@ void MainCLI::execute()
 			auto adminNetFace = new rpc::AdminNet(web3, sessionManager);
 			auto adminUtilsFace = new rpc::AdminUtils(sessionManager, this);
 
-			ModularServer<rpc::EthFace, rpc::DBFace, rpc::WhisperFace, rpc::NetFace, rpc::Web3Face, rpc::PersonalFace, rpc::AdminEthFace, rpc::AdminNetFace, rpc::AdminUtilsFace> rpcServer(ethFace, new rpc::LevelDB(), new rpc::Whisper(web3, {}), new rpc::Net(web3), new rpc::Web3(web3.clientVersion()), new rpc::Personal(m_keyManager), adminEthFace, adminNetFace, adminUtilsFace);
+			ModularServer<rpc::EthFace, rpc::DBFace, rpc::WhisperFace, rpc::NetFace, rpc::Web3Face, rpc::PersonalFace, rpc::AdminEthFace, rpc::AdminNetFace, rpc::AdminUtilsFace> rpcServer(ethFace, new rpc::LevelDB(), new rpc::Whisper(web3, {}), new rpc::Net(web3), new rpc::Web3(web3.clientVersion()), new rpc::Personal(m_keyManager, accountHolder), adminEthFace, adminNetFace, adminUtilsFace);
 
 			JSLocalConsole console;
 			rpcServer.addConnector(console.createConnector());
@@ -343,7 +343,7 @@ void MainCLI::startRPC(WebThreeDirect& _web3, TrivialGasPricer& _gasPricer)
 		auto adminEthFace = new rpc::AdminEth(*_web3.ethereum(), _gasPricer, m_keyManager, *m_rpcPrivate->sessionManager);
 		m_rpcPrivate->jsonrpcServer.reset(new ModularServer<rpc::EthFace, rpc::DBFace, rpc::WhisperFace,
 							rpc::NetFace, rpc::Web3Face, rpc::PersonalFace,
-							rpc::AdminEthFace, rpc::AdminNetFace, rpc::AdminUtilsFace>(ethFace, new rpc::LevelDB(), new rpc::Whisper(_web3, {}), new rpc::Net(_web3), new rpc::Web3(_web3.clientVersion()), new rpc::Personal(m_keyManager), adminEthFace, new rpc::AdminNet(_web3, *m_rpcPrivate->sessionManager), new rpc::AdminUtils(*m_rpcPrivate->sessionManager)));
+							rpc::AdminEthFace, rpc::AdminNetFace, rpc::AdminUtilsFace>(ethFace, new rpc::LevelDB(), new rpc::Whisper(_web3, {}), new rpc::Net(_web3), new rpc::Web3(_web3.clientVersion()), new rpc::Personal(m_keyManager, *m_rpcPrivate->accountHolder), adminEthFace, new rpc::AdminNet(_web3, *m_rpcPrivate->sessionManager), new rpc::AdminUtils(*m_rpcPrivate->sessionManager)));
 		if (m_jsonRPCPort > -1)
 		{
 			auto httpConnector = new SafeHttpServer(m_jsonRPCPort, "", "", SensibleHttpThreads);

--- a/flu/MainCLI.cpp
+++ b/flu/MainCLI.cpp
@@ -246,7 +246,15 @@ void MainCLI::execute()
 			auto adminNetFace = new rpc::AdminNet(web3, sessionManager);
 			auto adminUtilsFace = new rpc::AdminUtils(sessionManager, this);
 
-			ModularServer<rpc::EthFace, rpc::DBFace, rpc::WhisperFace, rpc::NetFace, rpc::Web3Face, rpc::PersonalFace, rpc::AdminEthFace, rpc::AdminNetFace, rpc::AdminUtilsFace> rpcServer(ethFace, new rpc::LevelDB(), new rpc::Whisper(web3, {}), new rpc::Net(web3), new rpc::Web3(web3.clientVersion()), new rpc::Personal(m_keyManager, accountHolder), adminEthFace, adminNetFace, adminUtilsFace);
+			ModularServer<
+				rpc::EthFace, rpc::DBFace, rpc::WhisperFace,
+				rpc::NetFace, rpc::Web3Face, rpc::PersonalFace,
+				rpc::AdminEthFace, rpc::AdminNetFace, rpc::AdminUtilsFace
+			> rpcServer(
+				ethFace, new rpc::LevelDB(), new rpc::Whisper(web3, {}),
+				new rpc::Net(web3), new rpc::Web3(web3.clientVersion()), new rpc::Personal(m_keyManager, accountHolder),
+				adminEthFace, adminNetFace, adminUtilsFace
+			);
 
 			JSLocalConsole console;
 			rpcServer.addConnector(console.createConnector());
@@ -323,7 +331,11 @@ namespace dev
 struct RPCPrivate
 {
 #if ETH_JSONRPC || !ETH_TRUE
-	unique_ptr<ModularServer<rpc::EthFace, rpc::DBFace, rpc::WhisperFace, rpc::NetFace, rpc::Web3Face, rpc::PersonalFace, rpc::AdminEthFace, rpc::AdminNetFace, rpc::AdminUtilsFace>> jsonrpcServer;
+	unique_ptr<ModularServer<
+		rpc::EthFace, rpc::DBFace, rpc::WhisperFace,
+		rpc::NetFace, rpc::Web3Face, rpc::PersonalFace,
+		rpc::AdminEthFace, rpc::AdminNetFace, rpc::AdminUtilsFace
+	>> jsonrpcServer;
 	unique_ptr<rpc::SessionManager> sessionManager;
 	unique_ptr<SimpleAccountHolder> accountHolder;
 #endif
@@ -341,9 +353,15 @@ void MainCLI::startRPC(WebThreeDirect& _web3, TrivialGasPricer& _gasPricer)
 		m_rpcPrivate->accountHolder.reset(new SimpleAccountHolder([&](){ return _web3.ethereum(); }, [](Address){ return string(); }, m_keyManager));
 		auto ethFace = new rpc::Eth(*_web3.ethereum(), *m_rpcPrivate->accountHolder);
 		auto adminEthFace = new rpc::AdminEth(*_web3.ethereum(), _gasPricer, m_keyManager, *m_rpcPrivate->sessionManager);
-		m_rpcPrivate->jsonrpcServer.reset(new ModularServer<rpc::EthFace, rpc::DBFace, rpc::WhisperFace,
-							rpc::NetFace, rpc::Web3Face, rpc::PersonalFace,
-							rpc::AdminEthFace, rpc::AdminNetFace, rpc::AdminUtilsFace>(ethFace, new rpc::LevelDB(), new rpc::Whisper(_web3, {}), new rpc::Net(_web3), new rpc::Web3(_web3.clientVersion()), new rpc::Personal(m_keyManager, *m_rpcPrivate->accountHolder), adminEthFace, new rpc::AdminNet(_web3, *m_rpcPrivate->sessionManager), new rpc::AdminUtils(*m_rpcPrivate->sessionManager)));
+		m_rpcPrivate->jsonrpcServer.reset(new ModularServer<
+			rpc::EthFace, rpc::DBFace, rpc::WhisperFace,
+			rpc::NetFace, rpc::Web3Face, rpc::PersonalFace,
+			rpc::AdminEthFace, rpc::AdminNetFace, rpc::AdminUtilsFace
+		>(
+			ethFace, new rpc::LevelDB(), new rpc::Whisper(_web3, {}),
+			new rpc::Net(_web3), new rpc::Web3(_web3.clientVersion()), new rpc::Personal(m_keyManager, *m_rpcPrivate->accountHolder),
+			adminEthFace, new rpc::AdminNet(_web3, *m_rpcPrivate->sessionManager), new rpc::AdminUtils(*m_rpcPrivate->sessionManager)
+		));
 		if (m_jsonRPCPort > -1)
 		{
 			auto httpConnector = new SafeHttpServer(m_jsonRPCPort, "", "", SensibleHttpThreads);

--- a/libweb3jsonrpc/AccountHolder.cpp
+++ b/libweb3jsonrpc/AccountHolder.cpp
@@ -23,7 +23,6 @@
 
 #include "AccountHolder.h"
 #include <random>
-#include <ctime>
 #include <libdevcore/Guards.h>
 #include <libethereum/Client.h>
 #include <libethcore/KeyManager.h>
@@ -112,9 +111,10 @@ TransactionNotification SimpleAccountHolder::authenticate(dev::eth::TransactionS
 	bool unlocked = false;
 	if (m_unlockedAccounts.count(_t.from))
 	{
-		time_t start = m_unlockedAccounts[_t.from].first;
-		unsigned duration = m_unlockedAccounts[_t.from].second;
-		if (duration > 0 && difftime(time(nullptr), start) < duration)
+		chrono::steady_clock::time_point start = m_unlockedAccounts[_t.from].first;
+		chrono::seconds duration(m_unlockedAccounts[_t.from].second);
+		auto end = start + duration;
+		if (start < end && chrono::steady_clock::now() < end)
 			unlocked = true;
 	}
 	if (!unlocked && m_getAuthorisation && !m_getAuthorisation(_t, isProxyAccount(_t.from)))
@@ -145,7 +145,8 @@ bool SimpleAccountHolder::unlockAccount(Address const& _account, const string& _
 		return false;
 
 	if (_duration == 0)
-		m_unlockedAccounts[_account] = make_pair(time(nullptr), 0);
+		// Lock it even if the password is wrong.
+		m_unlockedAccounts[_account].second = 0;
 
 	m_keyManager.notePassword(_password);
 
@@ -158,7 +159,7 @@ bool SimpleAccountHolder::unlockAccount(Address const& _account, const string& _
 	{
 		return false;
 	}
-	m_unlockedAccounts[_account] = make_pair(time(nullptr), _duration);
+	m_unlockedAccounts[_account] = make_pair(chrono::steady_clock::now(), _duration);
 
 	return true;
 }

--- a/libweb3jsonrpc/AccountHolder.cpp
+++ b/libweb3jsonrpc/AccountHolder.cpp
@@ -139,7 +139,7 @@ TransactionNotification SimpleAccountHolder::authenticate(dev::eth::TransactionS
 	return ret;
 }
 
-bool SimpleAccountHolder::unlockAccount(Address const& _account, const string& _password, unsigned _duration)
+bool SimpleAccountHolder::unlockAccount(Address const& _account, string const& _password, unsigned _duration)
 {
 	if (!m_keyManager.hasAccount(_account))
 		return false;

--- a/libweb3jsonrpc/AccountHolder.h
+++ b/libweb3jsonrpc/AccountHolder.h
@@ -75,6 +75,18 @@ public:
 	bool isProxyAccount(Address const& _account) const { return m_proxyAccounts.count(_account) > 0; }
 	Address const& defaultTransactAccount() const;
 
+	/// Automatically authenticate all transactions for the given account for the next @a _duration
+	/// seconds. Decrypt the key with @a _password if needed. @returns true on success.
+	/// Only works for direct accounts.
+	virtual bool unlockAccount(
+		Address const& /*_account*/,
+		std::string const& /*_password*/,
+		unsigned /*_duration*/
+	)
+	{
+		return false;
+	}
+
 	int addProxyAccount(Address const& _account);
 	bool removeProxyAccount(unsigned _id);
 	void queueTransaction(eth::TransactionSkeleton const& _transaction);
@@ -105,10 +117,13 @@ public:
 	AddressHash realAccounts() const override;
 	TransactionNotification authenticate(dev::eth::TransactionSkeleton const& _t) override;
 
+	virtual bool unlockAccount(Address const& _account, std::string const& _password, unsigned _duration) override;
+
 private:
 	std::function<std::string(Address)> m_getPassword;
 	std::function<bool(TransactionSkeleton const&, bool)> m_getAuthorisation;
 	KeyManager& m_keyManager;
+	std::map<Address, std::pair<time_t, unsigned>> m_unlockedAccounts;
 };
 
 class FixedAccountHolder: public AccountHolder

--- a/libweb3jsonrpc/AccountHolder.h
+++ b/libweb3jsonrpc/AccountHolder.h
@@ -27,6 +27,7 @@
 #include <algorithm>
 #include <vector>
 #include <map>
+#include <chrono>
 #include <libdevcrypto/Common.h>
 #include <libethcore/CommonJS.h>
 #include <libethereum/Transaction.h>
@@ -123,7 +124,7 @@ private:
 	std::function<std::string(Address)> m_getPassword;
 	std::function<bool(TransactionSkeleton const&, bool)> m_getAuthorisation;
 	KeyManager& m_keyManager;
-	std::map<Address, std::pair<time_t, unsigned>> m_unlockedAccounts;
+	std::map<Address, std::pair<std::chrono::steady_clock::time_point, unsigned>> m_unlockedAccounts;
 };
 
 class FixedAccountHolder: public AccountHolder

--- a/libweb3jsonrpc/Eth.cpp
+++ b/libweb3jsonrpc/Eth.cpp
@@ -262,6 +262,7 @@ string Eth::eth_sendTransaction(Json::Value const& _json)
 		BOOST_THROW_EXCEPTION(JsonRpcException(Errors::ERROR_RPC_INVALID_PARAMS));
 	}
 	BOOST_THROW_EXCEPTION(JsonRpcException(Errors::ERROR_RPC_INVALID_PARAMS));
+	return string();
 }
 
 string Eth::eth_signTransaction(Json::Value const& _json)

--- a/libweb3jsonrpc/Personal.cpp
+++ b/libweb3jsonrpc/Personal.cpp
@@ -1,4 +1,5 @@
 #include <libethcore/KeyManager.h>
+#include <libweb3jsonrpc/AccountHolder.h>
 #include <libethcore/CommonJS.h>
 #include "Personal.h"
 
@@ -7,7 +8,11 @@ using namespace dev;
 using namespace dev::rpc;
 using namespace dev::eth;
 
-Personal::Personal(dev::eth::KeyManager& _keyManager): m_keyManager(_keyManager) {}
+Personal::Personal(KeyManager& _keyManager, AccountHolder& _accountHolder):
+	m_keyManager(_keyManager),
+	m_accountHolder(_accountHolder)
+{
+}
 
 std::string Personal::personal_newAccount(std::string const& _password)
 {
@@ -18,22 +23,5 @@ std::string Personal::personal_newAccount(std::string const& _password)
 
 bool Personal::personal_unlockAccount(std::string const& _address, std::string const& _password, int _duration)
 {
-	(void)_duration;
-	Address address(fromHex(_address));
-
-	if (!m_keyManager.hasAccount(address))
-		return false;
-
-	m_keyManager.notePassword(_password);
-
-	try
-	{
-		m_keyManager.secret(address);
-	}
-	catch (PasswordUnknown const&)
-	{
-		return false;
-	}
-
-	return true;
+	return m_accountHolder.unlockAccount(Address(fromHex(_address, WhenError::Throw)), _password, _duration);
 }

--- a/libweb3jsonrpc/Personal.h
+++ b/libweb3jsonrpc/Personal.h
@@ -7,6 +7,7 @@ namespace dev
 namespace eth
 {
 class KeyManager;
+class AccountHolder;
 }
 
 namespace rpc
@@ -15,12 +16,13 @@ namespace rpc
 class Personal: public dev::rpc::PersonalFace
 {
 public:
-	Personal(dev::eth::KeyManager& _keyManager);
+	Personal(dev::eth::KeyManager& _keyManager, dev::eth::AccountHolder& _accountHolder);
 	virtual std::string personal_newAccount(std::string const& _password) override;
 	virtual bool personal_unlockAccount(std::string const& _address, std::string const& _password, int _duration) override;
 
 private:
 	dev::eth::KeyManager& m_keyManager;
+	dev::eth::AccountHolder& m_accountHolder;
 };
 
 }


### PR DESCRIPTION
An account can be unlocked for a certain number of seconds. After that time, the secret key will still be available in memory, but it will not be accessible via the rpc interfaces.

Fixes: https://github.com/ethereum/webthree-umbrella/issues/157

DEPENDS: {
"alethzero": "unlockAccount"
}
