### PR TITLE
Remove client name from version string.

### DIFF
--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -996,7 +996,7 @@ int main(int argc, char** argv)
 	auto nodesState = contents((dbPath.size() ? dbPath : getDataDir()) + "/network.rlp");
 	auto caps = useWhisper ? set<string>{"eth", "shh"} : set<string>{"eth"};
 	dev::WebThreeDirect web3(
-		WebThreeDirect::composeClientVersion("++eth", clientName),
+		WebThreeDirect::composeClientVersion("++eth"),
 		dbPath,
 		chainParams,
 		withExisting,
@@ -1164,7 +1164,7 @@ int main(int argc, char** argv)
 //	std::shared_ptr<eth::BasicGasPricer> gasPricer = make_shared<eth::BasicGasPricer>(u256(double(ether / 1000) / etherPrice), u256(blockFees * 1000));
 	std::shared_ptr<eth::TrivialGasPricer> gasPricer = make_shared<eth::TrivialGasPricer>(askPrice, bidPrice);
 	eth::Client* c = nodeMode == NodeMode::Full ? web3.ethereum() : nullptr;
-	StructuredLogger::starting(WebThreeDirect::composeClientVersion("++eth", clientName), dev::Version);
+	StructuredLogger::starting(WebThreeDirect::composeClientVersion("++eth"), dev::Version);
 	if (c)
 	{
 		c->setGasPricer(gasPricer);
@@ -1341,7 +1341,7 @@ int main(int argc, char** argv)
 		jsonrpcServer->StopListening();
 #endif
 
-	StructuredLogger::stopping(WebThreeDirect::composeClientVersion("++eth", clientName), dev::Version);
+	StructuredLogger::stopping(WebThreeDirect::composeClientVersion("++eth"), dev::Version);
 	auto netData = web3.saveNetwork();
 	if (!netData.empty())
 		writeFile((dbPath.size() ? dbPath : getDataDir()) + "/network.rlp", netData);

--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -996,7 +996,7 @@ int main(int argc, char** argv)
 	auto nodesState = contents((dbPath.size() ? dbPath : getDataDir()) + "/network.rlp");
 	auto caps = useWhisper ? set<string>{"eth", "shh"} : set<string>{"eth"};
 	dev::WebThreeDirect web3(
-		WebThreeDirect::composeClientVersion("++eth"),
+		WebThreeDirect::composeClientVersion("eth"),
 		dbPath,
 		chainParams,
 		withExisting,
@@ -1164,7 +1164,7 @@ int main(int argc, char** argv)
 //	std::shared_ptr<eth::BasicGasPricer> gasPricer = make_shared<eth::BasicGasPricer>(u256(double(ether / 1000) / etherPrice), u256(blockFees * 1000));
 	std::shared_ptr<eth::TrivialGasPricer> gasPricer = make_shared<eth::TrivialGasPricer>(askPrice, bidPrice);
 	eth::Client* c = nodeMode == NodeMode::Full ? web3.ethereum() : nullptr;
-	StructuredLogger::starting(WebThreeDirect::composeClientVersion("++eth"), dev::Version);
+	StructuredLogger::starting(WebThreeDirect::composeClientVersion("eth"), dev::Version);
 	if (c)
 	{
 		c->setGasPricer(gasPricer);
@@ -1341,7 +1341,7 @@ int main(int argc, char** argv)
 		jsonrpcServer->StopListening();
 #endif
 
-	StructuredLogger::stopping(WebThreeDirect::composeClientVersion("++eth"), dev::Version);
+	StructuredLogger::stopping(WebThreeDirect::composeClientVersion("eth"), dev::Version);
 	auto netData = web3.saveNetwork();
 	if (!netData.empty())
 		writeFile((dbPath.size() ? dbPath : getDataDir()) + "/network.rlp", netData);

--- a/flu/MainCLI.cpp
+++ b/flu/MainCLI.cpp
@@ -181,7 +181,7 @@ void MainCLI::execute()
 
 		auto nodesState = contents(m_dbPath + "/network.rlp");
 		dev::WebThreeDirect web3(
-			WebThreeDirect::composeClientVersion("flu", m_clientName),
+			WebThreeDirect::composeClientVersion("flu"),
 			m_dbPath,
 			m_chainParams,
 			WithExisting::Trust,

--- a/libwebthree/WebThree.cpp
+++ b/libwebthree/WebThree.cpp
@@ -102,9 +102,9 @@ bzz::Interface* WebThreeDirect::swarm() const
 	return m_swarm.get();
 }
 
-std::string WebThreeDirect::composeClientVersion(std::string const& _client, std::string const& _clientName)
+std::string WebThreeDirect::composeClientVersion(std::string const& _client)
 {
-	return _client + "-" + "v" + dev::Version + "-" + string(DEV_QUOTED(ETH_COMMIT_HASH)).substr(0, 8) + (ETH_CLEAN_REPO ? "" : "*") + "/" + _clientName + "/" DEV_QUOTED(ETH_BUILD_TYPE) "-" DEV_QUOTED(ETH_BUILD_PLATFORM);
+	return _client + "/" + "v" + dev::Version + "-" + string(DEV_QUOTED(ETH_COMMIT_HASH)).substr(0, 8) + (ETH_CLEAN_REPO ? "" : "*") + "/" DEV_QUOTED(ETH_BUILD_TYPE) "-" DEV_QUOTED(ETH_BUILD_PLATFORM);
 }
 
 p2p::NetworkPreferences const& WebThreeDirect::networkPreferences() const

--- a/libwebthree/WebThree.h
+++ b/libwebthree/WebThree.h
@@ -142,7 +142,7 @@ public:
 
 	// Misc stuff:
 
-	static std::string composeClientVersion(std::string const& _client, std::string const& _name);
+	static std::string composeClientVersion(std::string const& _client);
 	std::string const& clientVersion() const { return m_clientVersion; }
 	void setClientVersion(std::string const& _name) { m_clientVersion = _name; }
 

--- a/test/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/libweb3jsonrpc/jsonrpc.cpp
@@ -59,7 +59,7 @@ struct Setup
 		setup = true;
 
 		dev::p2p::NetworkPreferences nprefs(30303, std::string(), false);
-		web3 = new WebThreeDirect("++eth tests", "", true, {"eth", "shh"}, nprefs);
+		web3 = new WebThreeDirect("eth tests", "", true, {"eth", "shh"}, nprefs);
 		
 		web3->setIdealPeerCount(5);
 		web3->ethereum()->setForceMining(true);


### PR DESCRIPTION
Remove the client name from the version string reported via rpc and use `/` to separate components.

Fixes https://github.com/ethereum/webthree-umbrella/issues/128

DEPENDS: {
"alethzero": "noclientname"
}
