### PR TITLE
Normalizing the human-readable agent version string

### DIFF
--- a/libwebthree/WebThree.cpp
+++ b/libwebthree/WebThree.cpp
@@ -104,7 +104,14 @@ bzz::Interface* WebThreeDirect::swarm() const
 
 std::string WebThreeDirect::composeClientVersion(std::string const& _client)
 {
-	return _client + "/" + "v" + dev::Version + "-" + string(DEV_QUOTED(ETH_COMMIT_HASH)).substr(0, 8) + (ETH_CLEAN_REPO ? "" : "*") + "/" DEV_QUOTED(ETH_BUILD_TYPE) "-" DEV_QUOTED(ETH_BUILD_PLATFORM);
+	return _client + "/" + \
+		"v" + dev::Version + "/" + \
+		DEV_QUOTED(ETH_BUILD_OS) + "/" + \
+		DEV_QUOTED(ETH_BUILD_COMPILER) + "/" + \
+		DEV_QUOTED(ETH_BUILD_JIT_MODE) + "/" + \
+		DEV_QUOTED(ETH_BUILD_TYPE) + "/" + \
+		string(DEV_QUOTED(ETH_COMMIT_HASH)).substr(0, 8) + \
+		(ETH_CLEAN_REPO ? "" : "*") + "/";
 }
 
 p2p::NetworkPreferences const& WebThreeDirect::networkPreferences() const


### PR DESCRIPTION
DEPENDS:
{ "webthree-helpers":"extra_buildinfo_variables"
}

Normalizing the human-readable agent version string, as per discussions on gitter, in EIP and in Github issues.

Depends on changes in https://github.com/ethereum/webthree-helpers/pull/102.
Part of https://github.com/ethereum/webthree-umbrella/issues/128.
