### PR TITLE
Added missing CMake conditional around tests in webthree repo.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,4 +40,6 @@ add_subdirectory(libjsconsole)
 add_subdirectory(eth)
 
 # test stuff
-add_subdirectory(test)
+if (TESTS)
+	add_subdirectory(test)
+endif()


### PR DESCRIPTION
Spotted this because ethrpctest was showing up in the cross-builds, even with TESTS disabled.
