### PR TITLE
Provide simple key management for eth

### DIFF
--- a/eth/AccountManager.cpp
+++ b/eth/AccountManager.cpp
@@ -159,20 +159,20 @@ bool AccountManager::execute(int argc, char** argv)
 			for (int k = 3; k < argc; k++)
 			{
 				string i = argv[k];
-				if (h128 u = fromUUID(i))
+				if (isHex(i))
 				{
 					if (m_keyManager->store().recode(
-						u,
-						createPassword("Enter the new passphrase for key " + toUUID(u)),
-						[&](){ return getPassword("Enter the current passphrase for key " + toUUID(u) + ": "); },
+						Address(i),
+						createPassword("Enter the new passphrase for address " + i),
+						[&](){ return getPassword("Enter the current passphrase for address " + i + ": "); },
 						dev::KDF::Scrypt
 					))
-						cerr << "Re-encoded " << toUUID(u) << endl;
+						cerr << "Re-encoded " << i << endl;
 					else
-						cerr << "Couldn't re-encode " << toUUID(u) << "; key corrupt or incorrect passphrase supplied." << endl;
+						cerr << "Couldn't re-encode " << i << "; key corrupt or incorrect passphrase supplied." << endl;
 				}
 				else
-					cerr << "Couldn't re-encode " << i << "; not found." << endl;
+					cerr << "Couldn't re-encode " << i << "; does not represent an address." << endl;
 			}
 		}
 		else
@@ -213,7 +213,9 @@ bool AccountManager::openWallet()
 		m_keyManager.reset(new KeyManager());
 		if (m_keyManager->exists())
 		{
-			if (!m_keyManager->load(getPassword("Please enter your MASTER passphrase: ")))
+			if (m_keyManager->load(std::string()) || m_keyManager->load(getPassword("Please enter your MASTER passphrase: ")))
+				return true;
+			else
 			{
 				cerr << "Couldn't open wallet. Please check passphrase." << endl;
 				return false;

--- a/eth/AccountManager.cpp
+++ b/eth/AccountManager.cpp
@@ -33,7 +33,7 @@ void AccountManager::streamAccountHelp(ostream& _out)
 	_out
 		<< "    account list  List all keys available in wallet." << endl
 		<< "    account new	Create a new key and add it to the wallet." << endl
-		<< "    account update [<uuid>|<file>|<address> , ... ]  Decrypt and re-encrypt given keys." << endl
+		<< "    account update [<uuid>|<address> , ... ]  Decrypt and re-encrypt given keys." << endl
 		<< "    account import [<uuid>|<file>|<secret-hex>]	Import keys from given source and place in wallet." << endl;
 }
 

--- a/eth/AccountManager.cpp
+++ b/eth/AccountManager.cpp
@@ -33,7 +33,7 @@ void AccountManager::streamAccountHelp(ostream& _out)
 	_out
 		<< "    account list  List all keys available in wallet." << endl
 		<< "    account new	Create a new key and add it to the wallet." << endl
-		<< "    account update [ <uuid>|<file> , ... ]  Decrypt and re-encrypt given keys." << endl
+		<< "    account update [<address>]  Decrypt and re-encrypt given keys." << endl
 		<< "    account import [<uuid>|<file>|<secret-hex>]	Import keys from given source and place in wallet." << endl;
 }
 
@@ -163,8 +163,8 @@ bool AccountManager::execute(int argc, char** argv)
 				{
 					if (m_keyManager->store().recode(
 						Address(i),
-						createPassword("Enter the new passphrase for address " + i),
-						[&](){ return getPassword("Enter the current passphrase for address " + i + ": "); },
+						createPassword("Enter the new passphrase for the address " + i),
+						[&](){ return getPassword("Enter the current passphrase for the address " + i + ": "); },
 						dev::KDF::Scrypt
 					))
 						cerr << "Re-encoded " << i << endl;

--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -1156,16 +1156,10 @@ int main(int argc, char** argv)
 		}
 		else
 		{
-			if (!masterSet)
-				while (true)
-				{
-					masterPassword = getPassword("Please enter a MASTER password to protect your key store (make it strong!): ");
-					string confirm = getPassword("Please confirm the password by entering it again: ");
-					if (masterPassword == confirm)
-						break;
-					cout << "Passwords were different. Try again." << endl;
-				}
-			keyManager.create(masterPassword);
+			if (masterSet)
+				keyManager.create(masterPassword);
+			else
+				keyManager.create(std::string());
 		}
 	}
 	catch(...)


### PR DESCRIPTION
continuation of 
https://github.com/ethereum/webthree-umbrella/issues/297
- make everything work with addresses and not only UUIDs (recode option)
- by default create a wallet using empty password and don't ask the user for it 

DEPENDS: {
"libweb3core": "keyM2"
}
