### PR TITLE
Stripped remaining Solidity and LLL references from webthree

### DIFF
--- a/libweb3jsonrpc/CMakeLists.txt
+++ b/libweb3jsonrpc/CMakeLists.txt
@@ -7,7 +7,6 @@ file(GLOB HEADERS "*.h")
 add_library(${EXECUTABLE} ${SRC_LIST} ${HEADERS})
 
 eth_use(${EXECUTABLE} REQUIRED Web3::whisper Web3::webthree JsonRpc::Server)
-eth_use(${EXECUTABLE} OPTIONAL Solidity::solidity)
 
 jsonrpcstub_create(eth.json 
 	dev::rpc::EthFace ${CMAKE_CURRENT_SOURCE_DIR} EthFace 

--- a/libweb3jsonrpc/Eth.cpp
+++ b/libweb3jsonrpc/Eth.cpp
@@ -25,17 +25,11 @@
 #include <jsonrpccpp/common/exception.h>
 #include <libdevcore/CommonData.h>
 #include <libevmcore/Instruction.h>
-#include <liblll/Compiler.h>
 #include <libethereum/Client.h>
 #include <libethashseal/EthashClient.h>
 #include <libwebthree/WebThree.h>
 #include <libethcore/CommonJS.h>
 #include <libweb3jsonrpc/JsonHelper.h>
-#if ETH_SOLIDITY || !ETH_TRUE
-#include <libsolidity/interface/CompilerStack.h>
-#include <libsolidity/parsing/Scanner.h>
-#include <libsolidity/interface/SourceReferenceFormatter.h>
-#endif
 #include "Eth.h"
 #include "AccountHolder.h"
 #include "JsonHelper.h"

--- a/libweb3jsonrpc/JsonHelper.cpp
+++ b/libweb3jsonrpc/JsonHelper.cpp
@@ -23,7 +23,6 @@
 #include "JsonHelper.h"
 
 #include <libevmcore/Instruction.h>
-#include <liblll/Compiler.h>
 #include <libethcore/SealEngine.h>
 #include <libethereum/Client.h>
 #include <libwebthree/WebThree.h>


### PR DESCRIPTION
These should actually have been part of winsvega's earlier commit, but I missed them in the code review.

There are still solidity references in test/libweb3jsonrpc, but that appears not to matter because of this horror:

// @debris disabled as tests fail with:
// unknown location(0): fatal error in "jsonrpc_setMining": std::exception: Exception -32003 : Client connector error: : libcurl error: 28
// /home/gav/Eth/cpp-ethereum/test/jsonrpc.cpp(169): last checkpoint
# if ETH_JSONRPC && 0
