### PR TITLE
Upstreamed versions of my BuildInfo.h path edits from the cpp-ethereum repo merger branch

### DIFF
--- a/libwebthree/WebThree.cpp
+++ b/libwebthree/WebThree.cpp
@@ -29,8 +29,12 @@
 #include <libethereum/EthereumHost.h>
 #include <libwhisper/WhisperHost.h>
 #include <libethashseal/EthashClient.h>
-#include <libethashseal/Ethash.h>
+#if ETH_AFTER_REPOSITORY_MERGE
+#include "cpp-ethereum/BuildInfo.h"
+#else
 #include <ethereum/BuildInfo.h>
+#endif // ETH_AFTER_REPOSITORY_MERGE
+#include <libethashseal/Ethash.h>
 #include "Swarm.h"
 #include "Support.h"
 using namespace std;


### PR DESCRIPTION
They are inside pre-processor conditionals, which will be used to bridge the migration gap, and then removed when we are on the other side.
This pattern lets us share identical code between the two directory structures.
