### PR TITLE
link eth binary with custom add_executable

### DIFF
--- a/eth/CMakeLists.txt
+++ b/eth/CMakeLists.txt
@@ -4,7 +4,7 @@ set(EXECUTABLE eth)
 
 file(GLOB HEADERS "*.h")
 
-add_executable(${EXECUTABLE} ${SRC_LIST} ${HEADERS})
+eth_simple_add_executable(${EXECUTABLE} ${SRC_LIST} ${HEADERS})
 
 eth_use(${EXECUTABLE} REQUIRED Web3::web3jsonrpc JsonRpc::Client Web3::webthree Eth::ethcore Eth::p2p Eth::devcrypto Eth::ethereum Eth::ethashseal)
 eth_use(${EXECUTABLE} OPTIONAL Eth::evmjit)


### PR DESCRIPTION
Forces static linking for the `eth` target. Relates to ethereum/webthree-umbrella#337.

These changes should be pushed into ethereum/webthree-helpers#157, then here we'd only need to change `add_executable` to `eth_add_executable`. This could easily be done for all other targets as well.
