### PR TITLE
Add storageAt to web3.debug

### DIFF
--- a/libweb3jsonrpc/Debug.cpp
+++ b/libweb3jsonrpc/Debug.cpp
@@ -30,7 +30,6 @@ h256 Debug::blockHash(string const& _blockNumberOrHash) const
 Json::Value Debug::debug_trace(string const& _blockNumberOrHash, int _txIndex)
 {
 	Json::Value ret;
-
 	if (_txIndex < 0)
 		throw jsonrpc::JsonRpcException("Negative index");
 	Block block = m_eth.block(blockHash(_blockNumberOrHash));

--- a/libweb3jsonrpc/Debug.cpp
+++ b/libweb3jsonrpc/Debug.cpp
@@ -30,7 +30,7 @@ h256 Debug::blockHash(string const& _blockNumberOrHash) const
 Json::Value Debug::debug_trace(string const& _blockNumberOrHash, int _txIndex)
 {
 	Json::Value ret;
-	
+
 	if (_txIndex < 0)
 		throw jsonrpc::JsonRpcException("Negative index");
 	Block block = m_eth.block(blockHash(_blockNumberOrHash));
@@ -54,6 +54,21 @@ Json::Value Debug::debug_trace(string const& _blockNumberOrHash, int _txIndex)
 			cwarn << diagnostic_information(_e);
 		}
 	}
-	
+	return ret;
+}
+
+Json::Value Debug::debug_storageAt(string const& _blockNumberOrHash, int _txIndex, string const& _address)
+{
+	Json::Value ret(Json::objectValue);
+
+	if (_txIndex < 0)
+		throw jsonrpc::JsonRpcException("Negative index");
+	Block block = m_eth.block(blockHash(_blockNumberOrHash));
+	if ((unsigned)_txIndex < block.pending().size())
+	{
+		State state = block.fromPending(_txIndex);
+		for (auto const& i: state.storage(Address(_address)))
+			ret["0x" + toHex(toCompactBigEndian(i.first, 1))] = "0x" + toHex(toCompactBigEndian(i.second, 1));
+	}
 	return ret;
 }

--- a/libweb3jsonrpc/Debug.cpp
+++ b/libweb3jsonrpc/Debug.cpp
@@ -63,11 +63,11 @@ Json::Value Debug::debug_storageAt(string const& _blockNumberOrHash, int _txInde
 	if (_txIndex < 0)
 		throw jsonrpc::JsonRpcException("Negative index");
 	Block block = m_eth.block(blockHash(_blockNumberOrHash));
-	if ((unsigned)_txIndex < block.pending().size())
-	{
-		State state = block.fromPending(_txIndex);
-		for (auto const& i: state.storage(Address(_address)))
-			ret["0x" + toHex(toCompactBigEndian(i.first, 1))] = "0x" + toHex(toCompactBigEndian(i.second, 1));
-	}
+
+	unsigned i = ((unsigned)_txIndex < block.pending().size()) ? (unsigned)_txIndex : block.pending().size();
+	State state = block.fromPending(i);
+
+	for (auto const& i: state.storage(Address(_address)))
+		ret[toHex(toCompactBigEndian(i.first, 1), 2, HexPrefix::Add)] = toHex(toCompactBigEndian(i.second, 1), 2, HexPrefix::Add);
 	return ret;
 }

--- a/libweb3jsonrpc/Debug.h
+++ b/libweb3jsonrpc/Debug.h
@@ -25,10 +25,12 @@ public:
 	}
 
 	virtual Json::Value debug_trace(std::string const& _blockNumberOrHash, int _txIndex) override;
+	virtual Json::Value debug_storageAt(std::string const& _blockNumberOrHash, int _txIndex, std::string const& _address) override;
 
 private:
 	eth::Client& m_eth;
 	h256 blockHash(std::string const& _blockNumberOrHash) const;
+
 };
 
 }

--- a/libweb3jsonrpc/DebugFace.h
+++ b/libweb3jsonrpc/DebugFace.h
@@ -15,13 +15,19 @@ namespace dev {
                 DebugFace()
                 {
                     this->bindAndAddMethod(jsonrpc::Procedure("debug_trace", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT, "param1",jsonrpc::JSON_STRING,"param2",jsonrpc::JSON_INTEGER, NULL), &dev::rpc::DebugFace::debug_traceI);
+                    this->bindAndAddMethod(jsonrpc::Procedure("debug_storageAt", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT, "param1",jsonrpc::JSON_STRING,"param2",jsonrpc::JSON_INTEGER,"param3",jsonrpc::JSON_STRING, NULL), &dev::rpc::DebugFace::debug_storageAtI);
                 }
 
                 inline virtual void debug_traceI(const Json::Value &request, Json::Value &response)
                 {
                     response = this->debug_trace(request[0u].asString(), request[1u].asInt());
                 }
+                inline virtual void debug_storageAtI(const Json::Value &request, Json::Value &response)
+                {
+                    response = this->debug_storageAt(request[0u].asString(), request[1u].asInt(), request[2u].asString());
+                }
                 virtual Json::Value debug_trace(const std::string& param1, int param2) = 0;
+                virtual Json::Value debug_storageAt(const std::string& param1, int param2, const std::string& param3) = 0;
         };
 
     }

--- a/libweb3jsonrpc/debug.json
+++ b/libweb3jsonrpc/debug.json
@@ -1,3 +1,4 @@
 [
-{ "name": "debug_trace", "params": ["", 0], "returns": {}}
+{ "name": "debug_trace", "params": ["", 0], "returns": {}},
+{ "name": "debug_storageAt", "params": ["", 0, ""], "returns": {}}
 ]


### PR DESCRIPTION
allow to retrieve the storage just before the execution of the transaction designed by txIndex

storageAt( _blockNumberOrHash, _txIndex, _address)
