### PR TITLE
Do not generate vanity addresses by default

### DIFF
--- a/libweb3jsonrpc/Personal.cpp
+++ b/libweb3jsonrpc/Personal.cpp
@@ -17,7 +17,7 @@ Personal::Personal(KeyManager& _keyManager, AccountHolder& _accountHolder):
 
 std::string Personal::personal_newAccount(std::string const& _password)
 {
-	KeyPair p = KeyManager::newKeyPair(KeyManager::NewKeyType::DirectICAP);
+	KeyPair p = KeyManager::newKeyPair(KeyManager::NewKeyType::NoVanity);
 	m_keyManager.import(p.secret(), std::string(), _password, std::string());
 	return toJS(p.address());
 }


### PR DESCRIPTION
The previous behaviour was to try until the first byte of the address is zero so it would fit the ICAP standard. This is not done by geth and it slows down account creation considerably.
