### PR TITLE
Ignore KeyManager if master password empty and does not work.

### DIFF
--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -116,7 +116,7 @@ void help()
 		<< "    -S,--import-session-secret <secret>  Import a secret key into the key store and use as the default for this session only." << endl
 		<< "    --sign-key <address>  Sign all transactions with the key of the given address." << endl
 		<< "    --session-sign-key <address>  Sign all transactions with the key of the given address for this session only." << endl
-		<< "    --master <password>  Give the master password for the key store." << endl
+		<< "    --master <password>  Give the master password for the key store. Use --master \"\" to show a prompt." << endl
 		<< "    --password <password>  Give a password for a private key." << endl
 		<< endl
 		<< "Client transacting:" << endl
@@ -1106,13 +1106,8 @@ int main(int argc, char** argv)
 	{
 		if (keyManager.exists())
 		{
-			if (!keyManager.load(masterPassword))
+			if (!keyManager.load(masterPassword) && masterSet)
 			{
-				if (masterSet)
-				{
-					cerr << "Incorrect password specified." << endl;
-					return -1;
-				}
 				while (true)
 				{
 					masterPassword = getPassword("Please enter your MASTER password: ");


### PR DESCRIPTION
This enables `eth` to work without master password by default.

If the master password is empty, try to load the key manager info file with the empty password and just continue without the key manager features otherwise. If `--master ""` is used, try with that password and prompt for new passwords if it fails.
