### PR TITLE
Added missing json_spirit include to webthree tests

### DIFF
--- a/test/libwhisper/shhrpc.cpp
+++ b/test/libwhisper/shhrpc.cpp
@@ -36,6 +36,7 @@
 #include <libweb3jsonrpc/AdminUtils.h>
 #include <jsonrpccpp/server/connectors/httpserver.h>
 #include <jsonrpccpp/client/connectors/httpclient.h>
+#include <json_spirit/JsonSpiritHeaders.h>
 #include <test/TestHelper.h>
 #include <test/libweb3jsonrpc/WebThreeStubClient.h>
 #include <libethcore/KeyManager.h>


### PR DESCRIPTION
This is showing as problematic in the merge_repos branch.
Maybe we aren't even building Whisper tests, so we missed the build break?
