### PR TITLE
fix eth crashing on rpc reconnection

### DIFF
--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -102,6 +102,7 @@ void help()
 #if ETH_JSONRPC
 		<< "    -j,--json-rpc  Enable JSON-RPC server (default: off)." << endl
 		<< "    --ipc  Enable IPC server (default: on)." << endl
+		<< "    --ipcpath Set .ipc socket path (default: data directory)" << endl
 		<< "    --admin-via-http  Expose admin interface via http - UNSAFE! (default: off)." << endl
 		<< "    --no-ipc  Disable IPC server." << endl
 		<< "    --json-rpc-port <n>  Specify JSON-RPC server port (implies '-j', default: " << SensibleHttpPort << ")." << endl
@@ -562,6 +563,8 @@ int main(int argc, char** argv)
 			sessionKey = Address(fromHex(argv[++i]));
 		else if ((arg == "-d" || arg == "--path" || arg == "--db-path" || arg == "--datadir") && i + 1 < argc)
 			setDataDir(argv[++i]);
+		else if (arg == "--ipcpath" && i + 1 < argc )
+			setIpcPath(argv[++i]);
 		else if ((arg == "--genesis-json" || arg == "--genesis") && i + 1 < argc)
 		{
 			try

--- a/libweb3jsonrpc/UnixSocketServer.cpp
+++ b/libweb3jsonrpc/UnixSocketServer.cpp
@@ -42,18 +42,18 @@ string ipcSocketPath()
 #ifdef __APPLE__
 	// A bit hacky, but backwards compatible: If we did not change the default data dir,
 	// put the socket in ~/Library/Ethereum, otherwise in the set data dir.
-	string path = getDataDir();
+	string path = getIpcPath();
 	if (path == getDefaultDataDir())
 		return getenv("HOME") + string("/Library/Ethereum");
 	else
 		return path;
 #else
-	return getDataDir();
+	return getIpcPath();
 #endif
 }
 
 UnixDomainSocketServer::UnixDomainSocketServer(string const& _appId):
-	IpcServerBase(string(ipcSocketPath() + "/" + _appId + ".ipc").substr(0, c_pathMaxSize))
+	IpcServerBase(string(getIpcPath() + "/" + _appId + ".ipc").substr(0, c_pathMaxSize))
 {
 }
 

--- a/libweb3jsonrpc/UnixSocketServer.cpp
+++ b/libweb3jsonrpc/UnixSocketServer.cpp
@@ -120,12 +120,13 @@ void UnixDomainSocketServer::CloseConnection(int _socket)
 	close(_socket);
 }
 
+
 size_t UnixDomainSocketServer::Write(int _connection, string const& _data)
 {
-	int r = write(_connection, _data.data(), _data.size());
+	int r = send(_connection, _data.data(), _data.size(), MSG_NOSIGNAL);
 	if (r > 0)
 		return r;
-	return 0;	
+	return 0;
 }
 
 size_t UnixDomainSocketServer::Read(int _connection, void* _data, size_t _size)


### PR DESCRIPTION
connects to https://github.com/ethereum/webthree-umbrella/issues/677

+eth Ipc socket path 
so you could specify the ipc socket path different from the datadir and connect ethereumWallet to it
depends on https://github.com/ethereum/libweb3core/pull/95
connects to https://github.com/ethereum/webthree-umbrella/issues/678
