### PR TITLE
Fix macOS build in UnixSocketServer.cpp.

### DIFF
--- a/libweb3jsonrpc/UnixSocketServer.cpp
+++ b/libweb3jsonrpc/UnixSocketServer.cpp
@@ -31,6 +31,14 @@ along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 #include <libdevcore/Guards.h>
 #include <libdevcore/FileSystem.h>
 
+// "Mac OS X does not support the flag MSG_NOSIGNAL but we have an equivalent."
+// See http://lists.apple.com/archives/macnetworkprog/2002/Dec/msg00091.html
+#if defined(__APPLE__)
+	#if !defined(MSG_NOSIGNAL)
+		#define MSG_NOSIGNAL SO_NOSIGPIPE
+	#endif
+#endif
+
 using namespace std;
 using namespace jsonrpc;
 using namespace dev;


### PR DESCRIPTION
This break was a knock-on from the previous change to this file "fix eth crashing on rpc reconnection"
